### PR TITLE
Added german localization to CrossReference

### DIFF
--- a/CrossReference/i18n/de-formal.i18n.php
+++ b/CrossReference/i18n/de-formal.i18n.php
@@ -1,0 +1,36 @@
+<?php
+$messages['de-formal'] = array(
+	'crossreference_desc' => 'Erweiterung für automatisch nummerierte Querverweise, wie bei LaTeX',
+	'crossreference_noid' => 'Verweis-ID fehlt.',
+	'crossreference_noid_explanation' => 'Es muss das "id" Attribut im "reference" Tag angegeben werden. Methode: $1',
+
+	'crossreference_caption_fig' => 'Abbildung $1: $2',
+	'crossreference_ncaption_fig' => 'Abbildung $1',
+	'crossreference_caption_fig_s' => 'Abbildungen $1: $2',
+        'crossreference_ncaption_fig_s' => 'Abbildungen $1',
+
+	'crossreference_caption_def' => 'Definition $1: $2',
+        'crossreference_ncaption_def' => 'Definition $1',
+	'crossreference_caption_def_s' => 'Definitionen $1: $2',
+        'crossreference_ncaption_def_s' => 'Definitionen $1',
+
+	'crossreference_caption_tab' => 'Tabelle $1: $2',
+        'crossreference_ncaption_tab' => 'Tabelle $1',
+	'crossreference_caption_tab_s' => 'Tabellen $1: $2',
+        'crossreference_ncaption_tab_s' => 'Tabellen $1',
+
+	'crossreference_caption_eqn' => '($1)',
+        'crossreference_ncaption_eqn' => 'Formel ($1)',
+	'crossreference_caption_eqn_s' => '($1)',
+        'crossreference_ncaption_eqn_s' => 'Formeln ($1)',
+
+	'crossreference_caption_the' => 'Theorem $1: $2',
+        'crossreference_ncaption_the' => 'Theorem $1',
+	'crossreference_caption_the_s' => 'Theoreme $1: $2',
+        'crossreference_ncaption_the_s' => 'Theoreme $1',
+
+	'crossreference_caption_bib' => '[$1]&nbsp;$2',
+        'crossreference_ncaption_bib' => '[$1]',
+	'crossreference_caption_bib_s' => '[$1]&nbsp;$2',
+        'crossreference_ncaption_bib_s' => '[$1]',
+);

--- a/CrossReference/i18n/de.i18n.php
+++ b/CrossReference/i18n/de.i18n.php
@@ -1,0 +1,36 @@
+<?php
+$messages['de'] = array(
+	'crossreference_desc' => 'Erweiterung für automatisch nummerierte Querverweise, wie bei LaTeX',
+	'crossreference_noid' => 'Verweis-ID fehlt.',
+	'crossreference_noid_explanation' => 'Es muss das "id" Attribut im "reference" Tag angegeben werden. Methode: $1',
+
+	'crossreference_caption_fig' => 'Abbildung $1: $2',
+	'crossreference_ncaption_fig' => 'Abbildung $1',
+	'crossreference_caption_fig_s' => 'Abbildungen $1: $2',
+        'crossreference_ncaption_fig_s' => 'Abbildungen $1',
+
+	'crossreference_caption_def' => 'Definition $1: $2',
+        'crossreference_ncaption_def' => 'Definition $1',
+	'crossreference_caption_def_s' => 'Definitionen $1: $2',
+        'crossreference_ncaption_def_s' => 'Definitionen $1',
+
+	'crossreference_caption_tab' => 'Tabelle $1: $2',
+        'crossreference_ncaption_tab' => 'Tabelle $1',
+	'crossreference_caption_tab_s' => 'Tabellen $1: $2',
+        'crossreference_ncaption_tab_s' => 'Tabellen $1',
+
+	'crossreference_caption_eqn' => '($1)',
+        'crossreference_ncaption_eqn' => 'Formel ($1)',
+	'crossreference_caption_eqn_s' => '($1)',
+        'crossreference_ncaption_eqn_s' => 'Formeln ($1)',
+
+	'crossreference_caption_the' => 'Theorem $1: $2',
+        'crossreference_ncaption_the' => 'Theorem $1',
+	'crossreference_caption_the_s' => 'Theoreme $1: $2',
+        'crossreference_ncaption_the_s' => 'Theoreme $1',
+
+	'crossreference_caption_bib' => '[$1]&nbsp;$2',
+        'crossreference_ncaption_bib' => '[$1]',
+	'crossreference_caption_bib_s' => '[$1]&nbsp;$2',
+        'crossreference_ncaption_bib_s' => '[$1]',
+);


### PR DESCRIPTION
Hi, i created German localization files for your CrossReference plugin.
Unfortunately I had to add to files: "de" and "de-formal", even though they are identical in this case. "de" should usually be used by Mediawiki as a fallback if "de-formal" is not present, but I could not get it working for users with language setting "de-formal", so I created two files. I don't know if that is an issue with Mediawiki or your plugin.