### PR TITLE
Workaround for "UNIQ...QINU" bug in MediaWiki's parser.

### DIFF
--- a/CrossReference/CrossReference.class.php
+++ b/CrossReference/CrossReference.class.php
@@ -371,27 +371,31 @@ class ExtCrossReference
                         $this->lookup[$id]['group'] = $group;
 
 			// Expand text
-			$innerHtml = $parser->recursiveTagParse(trim($text));
+            // Normally, the following code would have been used:
+			// $innerHtml = $parser->recursiveTagParse(trim($text));
+            // ... However, as per MediaWiki 1.28, it doesn't work as
+            // expected (see https://www.mediawiki.org/wiki/QINU_fix)
+            // because a bug in MediaWiki's parser. The following
+            // workaround have to be used instead (only the following
+            // line):
+            $innerHtml = $wgOut->parseInline(trim($text));
 
+            $out = $innerHtml;
+			
 			// Build label
-			if (!isset($argv['noblock'])) {
-				$out .= "<div class='crossref-block' id='label-".
-					$id."'>";
-			}
 			if (isset($argv['showNumber']) || isset($argv['shownumber'])) {
-				$out .= "<span class='cross-id'>";
-				$out .= "(" . $num . ")";
-				$out .= "</span>";
+				$out = implode(array($out, " <span class='cross-id'>", "(", $num, ")", "</span>"));
 			}
 			if (!isset($argv['noblock'])) {
-			        $out .= "<span class='crossref-content'>";
+				$out = implode(array(
+                    "<div class='crossref-block' id='label-", $id, "'>",
+                    "<span class='crossref-content'>", $out, "</span>",
+                    "</div>"
+                ));
 			}
-		        $out .= $innerHtml;
-			if (!isset($argv['noblock'])) {
-			        $out .= "</span>";
-			        $out .= "</div>";	
-			}
-
+            // ... The following line is also a part of the workaround
+            // mentioned above:
+            $out = implode(array("<p>", $out,"</p>"));
 			if (isset($submatcher)) {
 				$submatcher->clear();
 				$submatcher = null;

--- a/CrossReference/CrossReference.class.php
+++ b/CrossReference/CrossReference.class.php
@@ -294,6 +294,7 @@ class ExtCrossReference
          */
         public function expandXrLabel( $text='', $argv='', $parser=null )
         {
+        global $wgOut;
 		wfProfileIn( __METHOD__ );
 
 		$out = '';
@@ -371,27 +372,31 @@ class ExtCrossReference
                         $this->lookup[$id]['group'] = $group;
 
 			// Expand text
-			$innerHtml = $parser->recursiveTagParse(trim($text));
+            // Normally, the following code would have been used:
+			// $innerHtml = $parser->recursiveTagParse(trim($text));
+            // ... However, as per MediaWiki 1.28, it doesn't work as
+            // expected (see https://www.mediawiki.org/wiki/QINU_fix)
+            // because a bug in MediaWiki's parser. The following
+            // workaround have to be used instead (only the following
+            // line):
+            $innerHtml = $wgOut->parseInline(trim($text));
 
+            $out = $innerHtml;
+			
 			// Build label
-			if (!isset($argv['noblock'])) {
-				$out .= "<div class='crossref-block' id='label-".
-					$id."'>";
-			}
 			if (isset($argv['showNumber']) || isset($argv['shownumber'])) {
-				$out .= "<span class='cross-id'>";
-				$out .= "(" . $num . ")";
-				$out .= "</span>";
+				$out = implode(array($out, " <span class='cross-id'>", "(", $num, ")", "</span>"));
 			}
 			if (!isset($argv['noblock'])) {
-			        $out .= "<span class='crossref-content'>";
+				$out = implode(array(
+                    "<div class='crossref-block' id='label-", $id, "'>",
+                    "<span class='crossref-content'>", $out, "</span>",
+                    "</div>"
+                ));
 			}
-		        $out .= $innerHtml;
-			if (!isset($argv['noblock'])) {
-			        $out .= "</span>";
-			        $out .= "</div>";	
-			}
-
+            // ... The following line is also a part of the workaround
+            // mentioned above:
+            $out = implode(array("<p>", $out,"</p>"));
 			if (isset($submatcher)) {
 				$submatcher->clear();
 				$submatcher = null;


### PR DESCRIPTION
To me, the problem seems to lay in the MediaWiki's parser (which is well-known to be "dark and full of terrors"). In theory, the following code is preferred and supposed to work:

$innerHtml = $parser->recursiveTagParse(trim($text));

However, although $text seems to be a valid wikitext, the $parser->recursiveTagParse() returns a "UNIQ...QINU" sequence (which is never supposed to be shown to the user in the first place). I've found a sort of a workaround for that, and use the following code instead:

$innerHtml = $wgOut->parseInline(trim($text));

Although in theory using $parser is preferred to using $wgOut directly. Therefore I hope they will resolve the issue with the parser in a future version of MediaWiki, and there will not be any need for this workaround.